### PR TITLE
Fixed 'My Batch' filter to exclude oneself

### DIFF
--- a/faces.py
+++ b/faces.py
@@ -147,9 +147,10 @@ def get_random_in_batch(cursor, current_user):
                           ON people.person_id = stints.person_id
                         INNER JOIN user_batch
                           ON stints.batch_id = user_batch.batch_id
+                      WHERE people.person_id != %s
                       ORDER BY random()
                       LIMIT 4""",
-                   [current_user])
+                   [current_user,current_user])
     return [x for x in cursor.fetchall()]
 
 @app.route('/api/people/random')


### PR DESCRIPTION
Fixed SQL query so that 'My Batch' filter excludes user's own data so one is not guessing about themselves.

Resolves #19 
