### PR TITLE
Compare strings without diactricts and symbols

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,13 @@
   "license": "GPL-3.0",
   "dependencies": {
     "immutable": "^3.8.1",
+    "jdu": "^1.0.0",
     "react": "^15.4.2",
+    "react-bootstrap": "0.30.8",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
     "react-scripts": "0.9.0",
-    "redux": "^3.6.0",
-    "react-bootstrap": "0.30.8"
+    "redux": "^3.6.0"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/core.js
+++ b/src/core.js
@@ -1,4 +1,5 @@
 import { Map, fromJS } from 'immutable';
+import { string_compare } from './string_compare'
 
 export const INITIAL_STATE = Map.of(
   'hint', Map.of('status', 'no hint'),
@@ -11,7 +12,7 @@ export const INITIAL_STATE = Map.of(
 );
 
 export function guess(state, guess) {
-  if (guess.toLowerCase() === state.getIn(['activePerson', '0', 'first_name']).toLowerCase()) {
+  if (string_compare(guess, state.getIn(['activePerson', '0', 'first_name']))) {
     return state.set('guess', Map.of('status', 'correct'));
   } else {
     return state.set('guess', Map.of('status', 'incorrect'));

--- a/src/string_compare.js
+++ b/src/string_compare.js
@@ -1,0 +1,27 @@
+import jdu from 'jdu'
+
+/**
+  * Compare a string case insensitive and diacritic insensitively
+  */
+export function string_compare(str1, str2) {
+    str1 = str1.toLowerCase();
+    str2 = str2.toLowerCase();
+
+    // Compare lowercase
+    if (str1 === str2) {
+        return true;
+    }
+
+    // Compare without diacritics
+    if (jdu.replace(str1) === jdu.replace(str2)) {
+        return true;
+    }
+
+    // Compare only letters and spaces
+    let regex = /[^\w\s]/g
+    if (str1.replace(regex, '') === str2.replace(regex, '')) {
+        return true;
+    }
+
+    return false;
+}

--- a/src/string_compare.test.js
+++ b/src/string_compare.test.js
@@ -1,0 +1,68 @@
+import {string_compare} from './string_compare'
+
+const cases = [
+  {
+    name: 'Foo',
+    guess: 'foo',
+    result: true
+  },
+  {
+    name: 'bâr',
+    guess: 'bar',
+    result: true
+  },
+  {
+    name: 'Barbara ğ',
+    guess: 'barbara g',
+    result: true
+  },
+  {
+    name: 'fIrSt ç',
+    guess: 'first c',
+    result: true
+  },
+  {
+    name: 'Nobile\'s',
+    guess: 'nobiles',
+    result: true
+  },
+  {
+    name: 'Mivá',
+    guess: 'miva',
+    result: true
+  },
+  {
+    name: 'Mârjorie',
+    guess: 'marjorie',
+    result: true
+  },
+  {
+    name: 'LIttlë',
+    guess: 'little',
+    result: true
+  },
+  {
+    name: 'LIttlë',
+    guess: 'Litttle',
+    result: false
+  },
+  {
+    name: 'Hermìne',
+    guess: 'hermine',
+    result: true
+  },
+  {
+    name: 'Hermìne',
+    guess: 'hemrine',
+    result: false
+  },
+];
+
+describe('string_compare', () => {
+  for (var i = 0, len = cases.length; i < len; i++) {
+    let c = cases[i]
+    it(`When name is ${c.name} then guessing ${c.guess} should be ${c.result}`, () => {
+      expect(string_compare(c.guess, c.name)).toBe(c.result);
+    });
+  }
+});


### PR DESCRIPTION
Fixes #18 

- I included the [jdu](https://github.com/mk7upurz87/jdu) package.
- We compare lowercase, then without diacritics, then only with letters and spaces.
- Added some tests.
- Extracted the `string_compare` function into it's own file.