### PR TITLE
Issue #32 - Add link to Directory profile to correct answers

### DIFF
--- a/src/components/guess.js
+++ b/src/components/guess.js
@@ -6,9 +6,15 @@ class Guess extends Component {
     const guess = this.props.guess;
     if (guess.get('status') === "correct") {
       let person = this.props.person;
+      let firstName = person.getIn(['0','first_name']);
+      let lastName = person.getIn(['0','last_name']);
+      let personId = person.getIn(['0','person_id']);
       return (
           <div className="guess-result correct-guess">
-            <p>Correct! Their Full Name is {person.getIn(['0','first_name'])} {person.getIn(['0','last_name'])}</p>
+            <p>Correct! Their Full Name
+            is <a href={`https://www.recurse.com/directory/${personId}`}>
+            {firstName} {lastName}</a>
+            </p>
           </div>
       );
     } else if (guess.get('status') === "incorrect") {


### PR DESCRIPTION
This commit resolves #32 by composing a link as formatted in the original issue -  `https://www.recurse.com/directory/[person ID]-[first name]-[last name]`. However, I wasn't sure how to test this with real data to look at edge cases for RCers with multiple names. 

Also, per the [API docs](https://github.com/recursecenter/wiki/wiki/Recurse-Center-API), I wonder if `profile.slug` is a better field to use or if it already accounts for unique first/last name cases. However, this field isn't currently in the database, so it would require a backend change.  

Looking forward to talking through this PR further!