### PR TITLE
Issue #44: Add Contributors File

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,19 @@
+# Faces Contributors
+
+Faces was originally conceived by [Jason Owen](https://github.com/jasonaowen)
+in early 2017 as a way for members of the
+[Recurse Center](https://www.recurse.com) community to get to know their fellow
+Recursers.
+
+Here is an inevitably incomplete list of MUCH-APPRECIATED CONTRIBUTORS --
+people who have submitted patches, reported bugs, provided feature ideas, helped
+answer questions, participated in code reviews, and generally made Faces that
+much better (listed alphabetically by first name):
+
+* [Alberto Torres](https://github.com/botwhytho)
+* [Fede Isas](https://github.com/fedeisas)
+* [Gwendolyn Weston](https://gwendolyn.io/)
+* [Jaryn Colbert](https://github.com/jaryncolbert)
+* [Jason Owen](https://github.com/jasonaowen)
+* [Sebastian Morr](https://github.com/blinry)
+* [Sumana Harihareswara](https://github.com/brainwane)


### PR DESCRIPTION
This commit resolves #44 by adding a markdown file with the initial list of seven Faces contributors. 