### PR TITLE
Functionality for more forgiving name guessing

### DIFF
--- a/src/components/guess.js
+++ b/src/components/guess.js
@@ -9,6 +9,7 @@ class Guess extends Component {
     if (guess.get('status') === "correct") {
       let person = this.props.person;
       let firstName = person.getIn(['0','first_name']);
+      let middleName = person.getIn(['0','middle_name']);
       let lastName = person.getIn(['0','last_name']);
       let personId = person.getIn(['0','person_id']);
       let stints = person.getIn(['0','stints']);
@@ -22,11 +23,20 @@ class Guess extends Component {
         stint_info = "";
       }
 
+      let nameParts = [];
+      if (middleName.length > 0) {
+        nameParts = [firstName, middleName, lastName];
+      } else {
+        nameParts = [firstName, lastName];
+      }
+
+      let displayName = nameParts.join(" ");
+
       return (
           <div className="guess-result correct-guess">
             <p>Correct! Their Full Name
             is <a href={`https://www.recurse.com/directory/${personId}`}> <br/>
-            {firstName} {lastName}</a> {stint_info}
+            {displayName}</a> {stint_info}
             </p>
           </div>
       );

--- a/src/core.js
+++ b/src/core.js
@@ -1,5 +1,6 @@
 import { Map, fromJS } from 'immutable';
 import { string_compare } from './string_compare'
+import { powerSet } from './name_variants'
 
 export const INITIAL_STATE = Map.of(
   'hint', Map.of('status', 'no hint'),
@@ -13,11 +14,47 @@ export const INITIAL_STATE = Map.of(
 );
 
 export function guess(state, guess) {
-  if (string_compare(guess, state.getIn(['activePerson', '0', 'first_name']))) {
+  let person = state.getIn(['activePerson', '0']);
+  let firstName = person.get('first_name');
+  let middleName = person.get('middle_name');
+  let lastName = person.get('last_name');
+  let variants = generateGuessVariants(firstName, middleName, lastName);
+
+  if (checkGuess(guess, variants)) {
     return state.set('guess', Map.of('status', 'correct'));
   } else {
     return state.set('guess', Map.of('status', 'incorrect'));
   }
+}
+
+export function generateGuessVariants(firstName, middleName, lastName) {
+  let nameParts = firstName.split(" ");
+
+  // Only use the middle name if it's in parentheses.
+  if (/^\(.*\)$/.test(middleName)) {
+    nameParts.push(middleName);
+  }
+
+  let variants = powerSet(nameParts);
+
+  // Filter out the empty set.
+  variants = new Set(Array.from(variants).filter(v => v.length > 0));
+
+  // For each variant, add one which also has the last name.
+  let variantsWithLastName = new Set(variants);
+  for (let variant of variants) {
+    let variantWithLastName = variant.slice(0)
+    variantWithLastName.push(lastName);
+    variantsWithLastName.add(variantWithLastName);
+  }
+
+  return new Set([...variants, ...variantsWithLastName])
+}
+
+export function checkGuess(guess, variants) {
+  return Array.from(variants).some((variant) => {
+    return string_compare(variant.join(" "), guess);
+  });
 }
 
 export function setActivePerson(state, person) {

--- a/src/core.test.js
+++ b/src/core.test.js
@@ -1,0 +1,31 @@
+import {checkGuess, generateGuessVariants} from './core'
+
+describe('checkGuess', () => {
+    it(`checks a simple case correctly`, () => {
+        expect(checkGuess("John", new Set([["John"]]))).toEqual(true);
+        expect(checkGuess("Paul", new Set([["John"]]))).toEqual(false);
+        expect(checkGuess("", new Set([["John"]]))).toEqual(false);
+    });
+    it(`checks a more complicated case correctly`, () => {
+        expect(checkGuess("John", generateGuessVariants("John Paul (JP)", "", ""))).toEqual(true);
+        expect(checkGuess("Paul", generateGuessVariants("John Paul (JP)", "", ""))).toEqual(true);
+        expect(checkGuess("John Paul", generateGuessVariants("John Paul (JP)", "", ""))).toEqual(true);
+        expect(checkGuess("Paul John", generateGuessVariants("John Paul (JP)", "", ""))).toEqual(false);
+        expect(checkGuess("J.P.", generateGuessVariants("John Paul (JP)", "", ""))).toEqual(true);
+        expect(checkGuess("JP", generateGuessVariants("John Paul (JP)", "", ""))).toEqual(true);
+    });
+    it(`checks if middle names are handled correctly`, () => {
+        expect(checkGuess("Sebastian", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("blinry", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("Blinry", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("Sebastian blinry", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("blinry", generateGuessVariants("Sebastian", "blinry", "Morr"))).toEqual(false);
+        expect(checkGuess("B", generateGuessVariants("Sebastian", "B.", "Morr"))).toEqual(false);
+    });
+    it(`checks if last names are handled correctly`, () => {
+        expect(checkGuess("Sebastian Morr", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("Sebastian blinry Morr", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("blinry Morr", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(true);
+        expect(checkGuess("Morr", generateGuessVariants("Sebastian", "(blinry)", "Morr"))).toEqual(false);
+    });
+});

--- a/src/name_variants.js
+++ b/src/name_variants.js
@@ -1,0 +1,18 @@
+export function powerSet(arr) {
+    let result = new Set();
+
+    // Base case
+    if (!arr.length)
+        return new Set([[]]);
+
+    let first = arr[0];
+    let set = powerSet(arr.slice(1))
+
+    for (let entry of set) {
+        result.add(entry.slice(0));
+        entry.unshift(first);
+        result.add(entry);
+    }
+
+    return result;
+}

--- a/src/name_variants.test.js
+++ b/src/name_variants.test.js
@@ -1,0 +1,22 @@
+import {powerSet} from './name_variants'
+
+describe('powerSet', () => {
+    it(`calculate power set of an empty array`, () => {
+        expect(powerSet([])).toEqual(new Set([[]]));
+    });
+
+    it(`ensure order of power set of 1 does not matter`, () => {
+        expect(powerSet([1])).toEqual(new Set([[], [1]]));
+        expect(powerSet([1])).toEqual(new Set([[1], []]));
+    });
+
+    it(`calculate power set of an array of size 2 correctly`, () => {
+        expect(powerSet([1,2])).toEqual(new Set([[], [1], [2], [1, 2]]));
+    });
+
+    it(`calculate power set of an array of size 3 correctly`, () => {
+        expect(powerSet([1,2,3])).toEqual(new Set([[], [1], [2], [3],
+            [1, 2], [1, 3], [2, 3], [1, 2, 3]]));
+    });
+});
+

--- a/update-data.py
+++ b/update-data.py
@@ -16,6 +16,7 @@ import argparse
 import json
 import logging
 import psycopg2
+import re
 import requests
 import sys
 
@@ -72,11 +73,17 @@ def insert_data(cursor, people):
     processed_batches = set()
 
     for person in people:
+        first_name = person.get('first_name')
+        last_name = person.get('last_name')
+        name = person.get('name')
+
+        middle_name = re.sub(r"^%s\s*(.*)\s+%s" % (re.escape(first_name), re.escape(last_name)), "\\1", name)
+
         logging.debug("Person #{}: {} {} {}; {}".format(
             person.get('id'),
-            person.get('first_name'),
-            person.get('middle_name'),
-            person.get('last_name'),
+            first_name,
+            middle_name,
+            last_name,
             person.get('image')
         ))
         cursor.execute("INSERT INTO people" +
@@ -84,9 +91,9 @@ def insert_data(cursor, people):
                        "  last_name, image_url)" +
                        " VALUES (%s, %s, %s, %s, %s)",
                        [person.get('id'),
-                        person.get('first_name'),
-                        person.get('middle_name'),
-                        person.get('last_name'),
+                        first_name,
+                        middle_name,
+                        last_name,
                         person.get('image_path')
                        ]
                       )


### PR DESCRIPTION
This PR does three things, which I feel could stay in separate commits: Putting the middle name in the database, displaying it in the UI, and generating several variants of how users can guess people's names correctly.

This is a rather large feature, and definitely needs to be reviewed. @jasonaowen, we can also do that in person, if you prefer. :)