### PR TITLE
Upgrade requests and urllib3 to address CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ MarkupSafe==1.1.1
 psycopg2==2.7.7
 pycparser==2.19
 python-dotenv==0.10.1
-requests==2.21.0
+requests==2.22.0
 six==1.12.0
-urllib3==1.24.1
+urllib3==1.25.3
 Werkzeug==0.15.1


### PR DESCRIPTION
Fix the [CVE-2019-11324 vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2019-11324) by upgrading urllib3 and requests to the latest available versions. I don't believe we're impacted by the vulnerability, as we do not explicitly specify any CA certificates.

See also #60.