### PR TITLE
Upgrade Flask and Jinja to address CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,11 +5,11 @@ cffi==1.12.2
 chardet==3.0.4
 Click==7.0
 cryptography==2.6.1
-Flask==1.0.2
+Flask==1.1.1
 gunicorn==19.9.0
 idna==2.8
 itsdangerous==1.1.0
-Jinja2==2.10
+Jinja2==2.10.1
 MarkupSafe==1.1.1
 psycopg2==2.7.7
 pycparser==2.19


### PR DESCRIPTION
The version of Jinja we were using, 2.10.0, contains [CVE-2019-10906](https://nvd.nist.gov/vuln/detail/CVE-2019-10906) in sandbox mode, which is functionality I don't believe we are using. Upgrade Jinja to [2.10.1](https://palletsprojects.com/blog/jinja-2-10-1-released/) to address the CVE, and since Jinja is a dependency of Flask, also upgrade Flask to version [1.1.1](https://flask.palletsprojects.com/en/1.1.x/changelog/#version-1-1-1). There don't appear to be any code changes needed for the new version of Flask.