### PR TITLE
Upgrade Werkzeug to address CVE

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,4 +17,4 @@ python-dotenv==0.10.1
 requests==2.22.0
 six==1.12.0
 urllib3==1.25.3
-Werkzeug==0.15.1
+Werkzeug==0.16.0


### PR DESCRIPTION
Upgrade to the latest version of Werkzeug, which includes the fix for [CVE-2019-14806](https://nvd.nist.gov/vuln/detail/CVE-2019-14806). As this project does not use Docker, and does not use the debugger in production, I believe it was not impacted by the CVE.

The [other changes in Werkzeug 0.16.0](https://werkzeug.palletsprojects.com/en/0.16.x/changes/#version-0-16-0) don't seem to require any code changes.