### PR TITLE
Update Heroku branch name in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -302,7 +302,7 @@ $ heroku addons:open scheduler
 
 Create a new job that runs daily, and set the command to `./update-data.py`.
 
-Then, in theory, it should be a simple `git push heroku master`!
+Then, in theory, it should be a simple `git push heroku main`!
 
 
 ## Troubleshooting


### PR DESCRIPTION
[Heroku supports deployment via git push to either `master` or `main`](https://devcenter.heroku.com/articles/git-branches). Update our documentation on spinning up a new Heroku environment to prefer `main`.

This pull request also serves to test that Travis CI will pick up the new default branch name.

Issue #78 Rename default branch